### PR TITLE
docs: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > A list of most common User Agent used on Internet.
 
-The list is auto generated, always up to date with the [most common user agents](https://techblog.willshouse.com/2012/01/03/most-common-user-agents/).
+The list is auto generated, always up to date with the most common user agents.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -50,9 +50,6 @@
     "standard-markdown": "latest",
     "standard-version": "latest"
   },
-  "engines": {
-    "node": ">= 10"
-  },
   "files": [
     "index.js",
     "index.json",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   },
   "files": [
     "index.js",
-    "index.json",
-    "scripts"
+    "index.json"
   ],
   "scripts": {
     "clean": "rm -rf node_modules",


### PR DESCRIPTION
Congrats on releasing 2.0.0 🎉

I noticed a few minor changes that could've been made when 2.0.0 released:

* The only JavaScript being shipped now is `index.js`. The `"node": ">= 10"` engine requirement is now unnecessary.
* The scripts directory was deleted so it can be removed from the `files` field as well.
* The techblog.willshouse.com link in the README is no longer relevant and is broken.